### PR TITLE
[DM-607] - Add new parameter to CreateCustomDomain endpoint

### DIFF
--- a/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
+++ b/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
@@ -97,16 +97,17 @@ namespace DopplerCustomDomain.Test
         }
 
         [Theory]
-        [InlineData("forms-landing", "doppler_forms_service_prod@docker")]
-        [InlineData("relay-tracking", "relay-actions-api_service_prod@docker")]
-        public async Task Create_custom_domain_should_send_all_keys_to_consul_when_success(string serviceName, string expectedServiceConfiguration)
+        [InlineData("forms-landing", "doppler_forms_service_prod@docker", "HTTP_HTTPS")]
+        [InlineData("relay-tracking", "relay-actions-api_service_prod@docker", "HTTP_HTTPS")]
+        public async Task Create_custom_domain_should_send_all_keys_to_consul_when_success(string serviceName, string expectedServiceConfiguration, string ruleTypeName)
         {
             // Arrange
             var fixture = new Fixture();
             var domainName = fixture.Create<string>();
             var domainConfiguration = new DomainConfiguration
             {
-                service = serviceName
+                service = serviceName,
+                ruleType = ruleTypeName
             };
             var expectedHttpsBaseUrl = $"/v1/kv/traefik/http/routers/https_{domainName}";
             var expectedHttpBaseUrl = $"/v1/kv/traefik/http/routers/http_{domainName}";

--- a/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
+++ b/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
@@ -97,9 +97,9 @@ namespace DopplerCustomDomain.Test
         }
 
         [Theory]
-        [InlineData("forms-landing", "doppler_forms_service_prod@docker", "HTTP_HTTPS")]
-        [InlineData("relay-tracking", "relay-actions-api_service_prod@docker", "HTTP_HTTPS")]
-        public async Task Create_custom_domain_should_send_all_keys_to_consul_when_success(string serviceName, string expectedServiceConfiguration, string ruleTypeName)
+        [InlineData("forms-landing", "doppler_forms_service_prod@docker", RuleType.HttpsOnly)]
+        [InlineData("relay-tracking", "relay-actions-api_service_prod@docker", RuleType.HttpsOnly)]
+        public async Task Create_custom_domain_should_send_all_keys_to_consul_when_success(string serviceName, string expectedServiceConfiguration, RuleType ruleTypeName)
         {
             // Arrange
             var fixture = new Fixture();

--- a/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
+++ b/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
@@ -6,8 +6,6 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -38,9 +36,10 @@ namespace DopplerCustomDomain.Test
             var fixture = new Fixture();
 
             var domainName = fixture.Create<string>();
-            var domainConfiguration = new DomainConfiguration
+            var domainConfiguration = new
             {
-                service = "relay-tracking"
+                service = "relay-tracking",
+                ruleType = "HttpsOnly"
             };
 
             var consulHttpClientMock = new Mock<IConsulHttpClient>();
@@ -72,9 +71,10 @@ namespace DopplerCustomDomain.Test
 
             var domainName = fixture.Create<string>();
             var serviceName = fixture.Create<string>();
-            var domainConfiguration = new DomainConfiguration
+            var domainConfiguration = new
             {
-                service = serviceName
+                service = serviceName,
+                ruleType = "HttpsOnly"
             };
 
             var consulHttpClientMock = new Mock<IConsulHttpClient>();
@@ -104,10 +104,10 @@ namespace DopplerCustomDomain.Test
             // Arrange
             var fixture = new Fixture();
             var domainName = fixture.Create<string>();
-            var domainConfiguration = new DomainConfiguration
+            var domainConfiguration = new
             {
                 service = serviceName,
-                ruleType = ruleTypeName
+                ruleType = ruleTypeName.ToString()
             };
             var expectedHttpsBaseUrl = $"/v1/kv/traefik/http/routers/https_{domainName}";
             var expectedHttpBaseUrl = $"/v1/kv/traefik/http/routers/http_{domainName}";
@@ -260,8 +260,11 @@ namespace DopplerCustomDomain.Test
 
             consulHttpClientMock.Verify(
                 x => x.DeleteRecurseAsync($"{httpBaseUrl}"),
-                Times.Once);
+                Times.Once());
 
+            consulHttpClientMock.Verify(
+                x => x.DeleteRecurseAsync($"{httpBaseUrl}/middlewares"),
+                Times.Once());
 
             consulHttpClientMock.VerifyNoOtherCalls();
         }
@@ -272,9 +275,10 @@ namespace DopplerCustomDomain.Test
             // Arrange
             var fixture = new Fixture();
             var domainName = fixture.Create<string>();
-            var domainConfiguration = new DomainConfiguration
+            var domainConfiguration = new
             {
-                service = "relay-tracking"
+                service = "relay-tracking",
+                ruleType = "HttpsOnly"
             };
 
             var consulHttpClientMock = new Mock<IConsulHttpClient>();
@@ -316,9 +320,10 @@ namespace DopplerCustomDomain.Test
             var fixture = new Fixture();
 
             var domainName = fixture.Create<string>();
-            var domainConfiguration = new DomainConfiguration
+            var domainConfiguration = new
             {
-                service = "relay-tracking"
+                service = "relay-tracking",
+                ruleType = "HttpsOnly"
             };
 
             var consulHttpClientMock = new Mock<IConsulHttpClient>();

--- a/DopplerCustomDomain/Controllers/CustomDomainController.cs
+++ b/DopplerCustomDomain/Controllers/CustomDomainController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace DopplerCustomDomain.Controllers
@@ -44,13 +45,7 @@ namespace DopplerCustomDomain.Controllers
                 return new NotFoundObjectResult($"Cannot find the service called: {domainConfiguration.service}");
             }
 
-            TraefikRuleTypeEnum ruleTypeEnum;
-            if (!Enum.TryParse(domainConfiguration.ruleType, out ruleTypeEnum))
-            {
-                ruleTypeEnum = TraefikRuleTypeEnum.HTTP;
-            }
-
-            await _customDomainProviderService.CreateCustomDomain(domainName, serviceName, ruleTypeEnum);
+            await _customDomainProviderService.CreateCustomDomain(domainName, serviceName, domainConfiguration.ruleType);
             return new OkObjectResult("Custom Domain Created");
         }
 

--- a/DopplerCustomDomain/Controllers/CustomDomainController.cs
+++ b/DopplerCustomDomain/Controllers/CustomDomainController.cs
@@ -3,6 +3,7 @@ using DopplerCustomDomain.DopplerSecurity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using System;
 using System.Threading.Tasks;
 
 namespace DopplerCustomDomain.Controllers
@@ -43,7 +44,13 @@ namespace DopplerCustomDomain.Controllers
                 return new NotFoundObjectResult($"Cannot find the service called: {domainConfiguration.service}");
             }
 
-            await _customDomainProviderService.CreateCustomDomain(domainName, serviceName);
+            TraefikRuleTypeEnum ruleTypeEnum;
+            if (!Enum.TryParse(domainConfiguration.ruleType, out ruleTypeEnum))
+            {
+                ruleTypeEnum = TraefikRuleTypeEnum.HTTP;
+            }
+
+            await _customDomainProviderService.CreateCustomDomain(domainName, serviceName, ruleTypeEnum);
             return new OkObjectResult("Custom Domain Created");
         }
 

--- a/DopplerCustomDomain/CustomDomainProvider/CustomDomainProviderService.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/CustomDomainProviderService.cs
@@ -16,34 +16,76 @@ namespace DopplerCustomDomain.CustomDomainProvider
             _consulHttpClient = consulHttpClient;
         }
 
-        public async Task CreateCustomDomain(string domain, string service, TraefikRuleTypeEnum ruleType)
+        public async Task CreateCustomDomain(string domain, string service, RuleType ruleType)
+        {
+            switch (ruleType)
+            {
+                case RuleType.HttpsOnly:
+                    await CreateHttps(domain, service);
+                    await CreateHttp(domain, service);
+                    await CreateRedirectRule(domain);
+                    break;
+                case RuleType.HttpsAndHttp:
+                    await CreateHttps(domain, service);
+                    await CreateHttp(domain, service);
+                    await DeleteRedirectRule(domain);
+                    break;
+                case RuleType.HttpOnly:
+                    await CreateHttp(domain, service);
+                    await DeleteRedirectRule(domain);
+                    await DeleteHttps(domain);
+                    break;
+            }
+        }
+
+        private async Task CreateHttps(string domain, string service)
         {
             var httpsBaseUrl = GenerateHttpsRouteConsulUrl(domain);
-            var httpBaseUrl = GenerateHttpRouteConsulUrl(domain);
 
-            if (ruleType == TraefikRuleTypeEnum.HTTP_HTTPS ||
-                ruleType == TraefikRuleTypeEnum.HTTP_HTTPS_WITHOUT_REDIRECT)
-            {
-                await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/entrypoints", "websecure_entry_point");
-                await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/tls/certresolver", "letsencryptresolver");
-                await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/rule", $"Host(`{domain}`)");
-                await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/service", service);
-            }
+            await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/entrypoints", "websecure_entry_point");
+            await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/tls/certresolver", "letsencryptresolver");
+            await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/rule", $"Host(`{domain}`)");
+            await _consulHttpClient.PutStringAsync($"{httpsBaseUrl}/service", service);
+        }
+
+        private async Task CreateHttp(string domain, string service)
+        {
+            var httpBaseUrl = GenerateHttpRouteConsulUrl(domain);
 
             await _consulHttpClient.PutStringAsync($"{httpBaseUrl}/entrypoints", "web_entry_point");
             await _consulHttpClient.PutStringAsync($"{httpBaseUrl}/service", service);
             await _consulHttpClient.PutStringAsync($"{httpBaseUrl}/rule", $"Host(`{domain}`)");
-            if (ruleType != TraefikRuleTypeEnum.HTTP_HTTPS_WITHOUT_REDIRECT &&
-                ruleType != TraefikRuleTypeEnum.HTTP)
-            {
-                await _consulHttpClient.PutStringAsync($"{httpBaseUrl}/middlewares", "http_to_https@file");
-            }
+        }
+
+        private async Task CreateRedirectRule(string domain)
+        {
+            var httpBaseUrl = GenerateHttpRouteConsulUrl(domain);
+            await _consulHttpClient.PutStringAsync($"{httpBaseUrl}/middlewares", "http_to_https@file");
         }
 
         public async Task DeleteCustomDomain(string domain)
         {
-            await _consulHttpClient.DeleteRecurseAsync($"{GenerateHttpsRouteConsulUrl(domain)}");
-            await _consulHttpClient.DeleteRecurseAsync($"{GenerateHttpRouteConsulUrl(domain)}");
+            await DeleteHttps(domain);
+            await DeleteHttp(domain);
+            await DeleteRedirectRule(domain);
+        }
+
+        private async Task DeleteHttps(string domain)
+        {
+            var httpsBaseUrl = GenerateHttpsRouteConsulUrl(domain);
+            await _consulHttpClient.DeleteRecurseAsync($"{httpsBaseUrl}");
+        }
+
+        private async Task DeleteHttp(string domain)
+        {
+            var httpBaseUrl = GenerateHttpRouteConsulUrl(domain);
+            await _consulHttpClient.DeleteRecurseAsync($"{httpBaseUrl}");
+        }
+
+        private async Task DeleteRedirectRule(string domain)
+        {
+            var httpBaseUrl = GenerateHttpRouteConsulUrl(domain);
+            await _consulHttpClient.DeleteRecurseAsync($"{httpBaseUrl}/middlewares");
         }
 
         private string GenerateHttpsRouteConsulUrl(string domain) =>

--- a/DopplerCustomDomain/CustomDomainProvider/DomainConfiguration.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/DomainConfiguration.cs
@@ -1,8 +1,13 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
 namespace DopplerCustomDomain.CustomDomainProvider
 {
     public class DomainConfiguration
     {
         public string service { get; set; } = string.Empty;
-        public string ruleType { get; set; } = string.Empty;
+        [EnumDataType(typeof(RuleType))]
+        public RuleType ruleType { get; set; }
     }
 }

--- a/DopplerCustomDomain/CustomDomainProvider/DomainConfiguration.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/DomainConfiguration.cs
@@ -3,5 +3,6 @@ namespace DopplerCustomDomain.CustomDomainProvider
     public class DomainConfiguration
     {
         public string service { get; set; } = string.Empty;
+        public string ruleType { get; set; } = string.Empty;
     }
 }

--- a/DopplerCustomDomain/CustomDomainProvider/ICustomDomainProviderService.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/ICustomDomainProviderService.cs
@@ -5,7 +5,7 @@ namespace DopplerCustomDomain.CustomDomainProvider
 {
     public interface ICustomDomainProviderService
     {
-        Task CreateCustomDomain(string domain, string service);
+        Task CreateCustomDomain(string domain, string service, TraefikRuleTypeEnum ruleType);
 
         Task DeleteCustomDomain(string domain);
     }

--- a/DopplerCustomDomain/CustomDomainProvider/ICustomDomainProviderService.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/ICustomDomainProviderService.cs
@@ -5,7 +5,7 @@ namespace DopplerCustomDomain.CustomDomainProvider
 {
     public interface ICustomDomainProviderService
     {
-        Task CreateCustomDomain(string domain, string service, TraefikRuleTypeEnum ruleType);
+        Task CreateCustomDomain(string domain, string service, RuleType ruleType);
 
         Task DeleteCustomDomain(string domain);
     }

--- a/DopplerCustomDomain/CustomDomainProvider/RuleType.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/RuleType.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 namespace DopplerCustomDomain.CustomDomainProvider
 {
-    public enum TraefikRuleTypeEnum
+    public enum RuleType
     {
-        HTTP_HTTPS,
-        HTTP_HTTPS_WITHOUT_REDIRECT,
-        HTTP
+        HttpsOnly = 1,
+        HttpsAndHttp,
+        HttpOnly
     }
 }

--- a/DopplerCustomDomain/CustomDomainProvider/TraefikRuleTypeEnum.cs
+++ b/DopplerCustomDomain/CustomDomainProvider/TraefikRuleTypeEnum.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DopplerCustomDomain.CustomDomainProvider
+{
+    public enum TraefikRuleTypeEnum
+    {
+        HTTP_HTTPS,
+        HTTP_HTTPS_WITHOUT_REDIRECT,
+        HTTP
+    }
+}

--- a/DopplerCustomDomain/Startup.cs
+++ b/DopplerCustomDomain/Startup.cs
@@ -4,9 +4,11 @@ using DopplerCustomDomain.DopplerSecurity;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.DataAnnotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System.Text.Json.Serialization;
 
 namespace DopplerCustomDomain
 {
@@ -34,6 +36,7 @@ namespace DopplerCustomDomain
                     options.JsonSerializerOptions.WriteIndented = true;
                     options.JsonSerializerOptions.PropertyNameCaseInsensitive = false;
                     options.JsonSerializerOptions.PropertyNamingPolicy = null!;
+                    options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter(allowIntegerValues: false));
                 });
             services.AddCors();
         }


### PR DESCRIPTION
This PR adds a new parameter to the CreateCustomDomain endpoint, to allow configuring the rules to be added in Traefik.
Depends of that parameter (ruleType) it's possible to add (or not) some rules:

- `HTTP_HTTPS` --> all rules are add
- `HTTP_HTTPS_WITHOUT_REDIRECT` --> all rules are added except for redirection
- `HTTP` --> only HTTP rules are add, without the redirect one

It's related to task [DM-607](https://makingsense.atlassian.net/browse/DM-607)