### PR TITLE
chore: include image name in version.txt

### DIFF
--- a/build-n-publish.sh
+++ b/build-n-publish.sh
@@ -181,7 +181,7 @@ fi
 
 docker build \
     -t "${imageName}:${canonicalTag}" \
-    --build-arg version="${versionFull}" \
+    --build-arg version="${imageName}:${canonicalTag}" \
     .
 
 if [ -n "${version}" ]


### PR DESCRIPTION
Hi team, this replaces the version number in `version.txt` with the full canonical image name.

This will allow us to read the text to confirm what is the service behind the URL.

<img width="720" alt="image" src="https://user-images.githubusercontent.com/1157864/107772440-01ff8680-6d1b-11eb-86f0-668f92b10272.png">

The idea is to apply the same approach in other repositories too.

Could you review it?