### PR TITLE
DE-348 - Validate custom domains step3

### DIFF
--- a/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
+++ b/DopplerCustomDomain.Test/CustomDomainEndpointTest.cs
@@ -367,7 +367,7 @@ namespace DopplerCustomDomain.Test
 
             var dnsResolutionValidatorMock = CreateDnsResolutionValidatorMock();
             dnsResolutionValidatorMock.Setup(x => x.ValidateAsync(domainName))
-                .ReturnsAsync(new DnsValidationResult(domainName, true, DnsValidationVerdict.Allow));
+                .ReturnsAsync(new PointingToUsDnsValidationResult(domainName));
 
             using var appFactory = _factory.WithBypassAuthorization();
 
@@ -391,7 +391,7 @@ namespace DopplerCustomDomain.Test
 
             var dnsResolutionValidatorMock = CreateDnsResolutionValidatorMock();
             dnsResolutionValidatorMock.Setup(x => x.ValidateAsync(domainName))
-                .ReturnsAsync(new DnsValidationResult(domainName, false, DnsValidationVerdict.Allow));
+                .ReturnsAsync(new NotPointingToUsDnsValidationResult(domainName, DnsValidationVerdict.Allow));
 
             using var appFactory = _factory.WithBypassAuthorization();
 
@@ -420,7 +420,7 @@ namespace DopplerCustomDomain.Test
             var customDomainProviderServiceMock = CreateCustomDomainProviderServiceMock();
             var dnsResolutionValidatorMock = CreateDnsResolutionValidatorMock();
             dnsResolutionValidatorMock.Setup(x => x.ValidateAsync(domainName)).
-                ReturnsAsync(new DnsValidationResult(domainName, false, DnsValidationVerdict.Allow));
+                ReturnsAsync(new NotPointingToUsDnsValidationResult(domainName, DnsValidationVerdict.Allow));
 
             var customDomainControllerLoggerMock = new Mock<ILogger<CustomDomainController>>();
 
@@ -442,7 +442,7 @@ namespace DopplerCustomDomain.Test
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             customDomainProviderServiceMock.Verify(x => x.CreateCustomDomain(domainName, expectedService, expectedRuleType), Times.Once);
             customDomainProviderServiceMock.Verify(x => x.CreateCustomDomain(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RuleType>()), Times.Once);
-            customDomainControllerLoggerMock.VerifyLog(LogLevel.Warning, $"WARNING: {domainName} does not resolve to our service IP address. Result: DnsValidationResult {{ DomainName = {domainName}, IsPointingToOurService = False, Verdict = Allow }}", Times.Once);
+            customDomainControllerLoggerMock.VerifyLog(LogLevel.Warning, $"WARNING: {domainName} does not resolve to our service IP address. Result: NotPointingToUsDnsValidationResult {{ DomainName = {domainName}, IsPointingToOurService = False, Verdict = Allow }}", Times.Once);
         }
 
         [Fact]
@@ -459,7 +459,7 @@ namespace DopplerCustomDomain.Test
             var customDomainProviderServiceMock = CreateCustomDomainProviderServiceMock();
             var dnsResolutionValidatorMock = CreateDnsResolutionValidatorMock();
             dnsResolutionValidatorMock.Setup(x => x.ValidateAsync(domainName))
-                .ReturnsAsync(new DnsValidationResult(domainName, true, DnsValidationVerdict.Allow));
+                .ReturnsAsync(new PointingToUsDnsValidationResult(domainName));
 
             var customDomainControllerLoggerMock = new Mock<ILogger<CustomDomainController>>();
 
@@ -497,7 +497,7 @@ namespace DopplerCustomDomain.Test
             var customDomainProviderServiceMock = CreateCustomDomainProviderServiceMock();
             var dnsResolutionValidatorMock = CreateDnsResolutionValidatorMock();
             dnsResolutionValidatorMock.Setup(x => x.ValidateAsync(domainName)).
-                ReturnsAsync(new DnsValidationResult(domainName, false, unknownVerdict));
+                ReturnsAsync(new NotPointingToUsDnsValidationResult(domainName, unknownVerdict));
 
             using var appFactory = _factory.WithBypassAuthorization();
 
@@ -518,7 +518,7 @@ namespace DopplerCustomDomain.Test
             // Assert
             Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
             customDomainProviderServiceMock.Verify(x => x.CreateCustomDomain(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RuleType>()), Times.Never);
-            customDomainControllerLoggerMock.VerifyLog(LogLevel.Error, $"Error: DNS validation result DnsValidationResult {{ DomainName = {domainName}, IsPointingToOurService = False, Verdict = {(int)unknownVerdict} }} has an unknown verdict: {(int)unknownVerdict}", Times.Once);
+            customDomainControllerLoggerMock.VerifyLog(LogLevel.Error, $"Error: DNS validation result NotPointingToUsDnsValidationResult {{ DomainName = {domainName}, IsPointingToOurService = False, Verdict = {(int)unknownVerdict} }} has an unknown verdict: {(int)unknownVerdict}", Times.Once);
         }
 
     }

--- a/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
+++ b/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace DopplerCustomDomain.DnsValidation
 {
-    public record DnsValidationResult(
+    public abstract record DnsValidationResult(
         string DomainName,
         bool IsPointingToOurService,
         DnsValidationVerdict Verdict

--- a/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
+++ b/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
@@ -4,11 +4,13 @@ namespace DopplerCustomDomain.DnsValidation
 {
     public record DnsValidationResult(
         string DomainName,
-        bool IsPointingToOurService
+        bool IsPointingToOurService,
+        DnsValidationVerdict Verdict
     );
 
     public record DnsValidationResultWithException(
         string DomainName,
-        Exception Exception
-    ) : DnsValidationResult(DomainName, false);
+        Exception Exception,
+        DnsValidationVerdict Verdict
+    ) : DnsValidationResult(DomainName, false, Verdict);
 }

--- a/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
+++ b/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
@@ -8,6 +8,15 @@ namespace DopplerCustomDomain.DnsValidation
         DnsValidationVerdict Verdict
     );
 
+    public record PointingToUsDnsValidationResult(
+        string DomainName
+    ) : DnsValidationResult(DomainName, true, DnsValidationVerdict.Allow);
+
+    public record NotPointingToUsDnsValidationResult(
+        string DomainName,
+        DnsValidationVerdict Verdict
+    ) : DnsValidationResult(DomainName, false, Verdict);
+
     public record DnsValidationResultWithException(
         string DomainName,
         Exception Exception,

--- a/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
+++ b/DopplerCustomDomain/DnsValidation/DnsValidationResult.cs
@@ -1,7 +1,14 @@
+using System;
+
 namespace DopplerCustomDomain.DnsValidation
 {
     public record DnsValidationResult(
         string DomainName,
         bool IsPointingToOurService
     );
+
+    public record DnsValidationResultWithException(
+        string DomainName,
+        Exception Exception
+    ) : DnsValidationResult(DomainName, false);
 }

--- a/DopplerCustomDomain/DnsValidation/DnsValidationVeredict.cs
+++ b/DopplerCustomDomain/DnsValidation/DnsValidationVeredict.cs
@@ -1,0 +1,7 @@
+namespace DopplerCustomDomain.DnsValidation
+{
+    public enum DnsValidationVerdict
+    {
+        Allow = 0,
+    }
+}

--- a/DopplerCustomDomain/DnsValidation/SystemDnsResolutionValidator.cs
+++ b/DopplerCustomDomain/DnsValidation/SystemDnsResolutionValidator.cs
@@ -26,7 +26,8 @@ namespace DopplerCustomDomain.DnsValidation
             try
             {
                 var result = await Dns.GetHostAddressesAsync(domainName);
-                return new DnsValidationResult(domainName, result.All(_expectedIPs.Contains), DnsValidationVerdict.Allow);
+                return result.All(_expectedIPs.Contains) ? new PointingToUsDnsValidationResult(domainName)
+                    : new NotPointingToUsDnsValidationResult(domainName, DnsValidationVerdict.Allow);
             }
             catch (Exception e)
             {

--- a/DopplerCustomDomain/DnsValidation/SystemDnsResolutionValidator.cs
+++ b/DopplerCustomDomain/DnsValidation/SystemDnsResolutionValidator.cs
@@ -31,7 +31,7 @@ namespace DopplerCustomDomain.DnsValidation
             catch (Exception e)
             {
                 _logger.LogWarning(e, "Error resolving IP address for {domainName}, assuming that it is not pointing to our service", domainName);
-                return new DnsValidationResult(domainName, false);
+                return new DnsValidationResultWithException(domainName, e);
             }
         }
     }

--- a/DopplerCustomDomain/DnsValidation/SystemDnsResolutionValidator.cs
+++ b/DopplerCustomDomain/DnsValidation/SystemDnsResolutionValidator.cs
@@ -26,12 +26,12 @@ namespace DopplerCustomDomain.DnsValidation
             try
             {
                 var result = await Dns.GetHostAddressesAsync(domainName);
-                return new DnsValidationResult(domainName, result.All(_expectedIPs.Contains));
+                return new DnsValidationResult(domainName, result.All(_expectedIPs.Contains), DnsValidationVerdict.Allow);
             }
             catch (Exception e)
             {
                 _logger.LogWarning(e, "Error resolving IP address for {domainName}, assuming that it is not pointing to our service", domainName);
-                return new DnsValidationResultWithException(domainName, e);
+                return new DnsValidationResultWithException(domainName, e, DnsValidationVerdict.Allow);
             }
         }
     }


### PR DESCRIPTION
@elsupergomez @swidzinskiMS 

Here I am basically introducing the concept of _validation verdict_ to allow the validator to indicate what to do.

I am thinking about these 3 behaviors when a domain name does not resolve to our IP:
* Allow (Store the domain anyway and return 200)
* Block (Return 400 error)
* Ignore (Return 200, but does not save the domain)

Probably the first step will be ignoring the errors to avoid breaking the clients.