### PR TITLE
build: fix tag detection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,5 +102,5 @@ def CHANGE_ID = env.CHANGE_ID
 // workaround https://issues.jenkins-ci.org/browse/JENKINS-55987
 // TODO: read this value from Jenkins provided metadata
 def String readCurrentTag() {
-    return sh(returnStdout: true, script: "git describe --tags --match v?*.?*.?* --abbrev=0 --exact-match || echo ''").trim()
+    return sh(returnStdout: true, script: 'echo ${TAG_NAME}').trim()
 }


### PR DESCRIPTION
Without this change, when the commit was already built, the build of the tag does not run.

It seems that this code is working better, but, since I will not test it, I will not merge it.

See related code: https://github.com/FromDoppler/doppler-shopify/pull/69

